### PR TITLE
Fix Aqara T1 led strip preset value range and given them names

### DIFF
--- a/tests/test_xiaomi.py
+++ b/tests/test_xiaomi.py
@@ -86,6 +86,7 @@ from zhaquirks.xiaomi.aqara.led_strip_t1 import (
     LedStripT1AudioEffect,
     LedStripT1AudioSensitivity,
     LedStripT1PowerOnStateMode,
+    LedStripT1Preset,
 )
 from zhaquirks.xiaomi.aqara.light_acn import AqaraLightT1M, LumiPowerOnStateMode
 import zhaquirks.xiaomi.aqara.magnet_ac01
@@ -2382,14 +2383,14 @@ def test_t1_led_strip(zigpy_device_from_v2_quirk):
     assert cluster_listener.attribute_updates[6][1] == LedStripT1AudioEffect.Rainbow
 
     # Checking preset attribute update
-    aqara_cluster.update_attribute(AqaraLedStripT1.AttributeDefs.preset.id, 7)
+    aqara_cluster.update_attribute(AqaraLedStripT1.AttributeDefs.preset.id, LedStripT1Preset.Sweep)
     assert len(cluster_listener.attribute_updates) == 8
     assert (
         cluster_listener.attribute_updates[7][0]
         == AqaraLedStripT1.AttributeDefs.preset.id
     )
 
-    assert cluster_listener.attribute_updates[7][1] == 7
+    assert cluster_listener.attribute_updates[7][1] == LedStripT1Preset.Sweep
 
     # Checking speed attribute update
     aqara_cluster.update_attribute(AqaraLedStripT1.AttributeDefs.speed.id, 77)

--- a/zhaquirks/xiaomi/aqara/led_strip_t1.py
+++ b/zhaquirks/xiaomi/aqara/led_strip_t1.py
@@ -42,6 +42,17 @@ class LedStripT1AudioEffect(t.enum32):
     Rainbow = 0x02
     Wave = 0x03
 
+class LedStripT1Preset(t.enum32):
+    "Aqara led strip preset."
+
+    Breathe = 0x00
+    Rainbow = 0x01
+    Sweep = 0x02
+    Flashing = 0x03
+    Strobe = 0x04
+    ReversedRainbow = 0x05
+    Colorful = 0x06
+    Scan = 0x07
 
 MIN_BRIGHTNESS_ID = 0x0515
 MAX_BRIGHTNESS_ID = 0x0516
@@ -101,7 +112,10 @@ class AqaraLedStripT1(XiaomiAqaraE1Cluster):
         )
 
         preset: Final = ZCLAttributeDef(
-            id=PRESET_ID, type=t.uint32_t, is_manufacturer_specific=True
+            id=PRESET_ID, 
+            type=LedStripT1Preset, 
+            zcl_type=DataTypeId.uint32, 
+            is_manufacturer_specific=True
         )
 
         speed: Final = ZCLAttributeDef(
@@ -172,12 +186,10 @@ class AqaraLedStripT1(XiaomiAqaraE1Cluster):
         translation_key="audio_effect",
         fallback_name="Audio effect",
     )
-    .number(
+    .enum(
         AqaraLedStripT1.AttributeDefs.preset.name,
+        LedStripT1Preset,
         AqaraLedStripT1.cluster_id,
-        min_value=1,
-        max_value=32,
-        step=1,
         translation_key="preset",
         fallback_name="Preset",
     )


### PR DESCRIPTION
## Proposed change

Thank you for the original PR! I have tested it on my T1 LED Stripe and made two improvements:

- Preset value range changed from 1-32 to 0-8,
- Give all presets human-readable names.

## Additional information

I have tested with my Aqara T1 LED Strip, and only presets 0 to 8 work. The slider range in the original commit was set to 1 - 32.

I also gave these presets human-readable names for easier use. I don't have an Aqara hub, so I'm unsure of the original name of these presets in the app. But these names should be descriptive enough.

## Device diagnostics

[zha-a80175402b837cc97c25162183cd8e67-Aqara Led strip T1-a786564debde71d7b06933d811346c14.json](https://github.com/user-attachments/files/22451861/zha-a80175402b837cc97c25162183cd8e67-Aqara.Led.strip.T1-a786564debde71d7b06933d811346c14.json)


## Checklist

- [x] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [x] Tests have been added to verify that the new code works
- [x] Device diagnostics data has been attached
